### PR TITLE
Fix Shellcheck SC2006

### DIFF
--- a/agents/plugins/fail2ban
+++ b/agents/plugins/fail2ban
@@ -20,11 +20,10 @@
 
 if [ -x /usr/bin/fail2ban-client ]; then
 echo "<<<fail2ban>>>"
-jails=`/usr/bin/fail2ban-client status | grep "Jail list" | sed -e 's/.*://' -e 's/,//g'`
+jails="$(/usr/bin/fail2ban-client status | grep "Jail list" | sed -e 's/.*://' -e 's/,//g')"
 	echo "Detected jails: $jails"
 	for jail in $jails
 	do
 		/usr/bin/fail2ban-client status "$jail"
 	done
 fi
-


### PR DESCRIPTION
Use $(...) notation instead of legacy backticked `...`.

Reference: https://github.com/koalaman/shellcheck/wiki/SC2006