### PR TITLE
Backery support, parse function and some little improvements

### DIFF
--- a/agents/plugins/fail2ban
+++ b/agents/plugins/fail2ban
@@ -24,6 +24,6 @@ jails="$(/usr/bin/fail2ban-client status | grep "Jail list" | sed -e 's/.*://' -
 	echo "Detected jails: $jails"
 	for jail in $jails
 	do
-		/usr/bin/fail2ban-client status "$jail"
+		/usr/bin/fail2ban-client status "$jail" | grep -v "Banned IP list:"
 	done
 fi

--- a/lib/check_mk/base/cee/plugins/bakery/fail2ban.py
+++ b/lib/check_mk/base/cee/plugins/bakery/fail2ban.py
@@ -3,19 +3,19 @@
 # Copyright (C) 2019 tribe29 GmbH - License: Checkmk Enterprise License
 # This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
 # conditions defined in the file COPYING, which is part of this source code package.
+
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
-from .bakery_api.v1 import FileGenerator, OS, Plugin, register
+from .bakery_api.v1 import FileGenerator, OS, Plugin, PluginConfig, register
 
-
-def get_fail2ban_files(conf: Any) -> FileGenerator:
-    yield Plugin(base_os=OS.LINUX, source=Path("fail2ban"))
-
+def get_fail2ban_files(conf: Dict[str, Any]) -> FileGenerator:
+    interval = conf.get('interval')
+    yield Plugin(base_os=OS.LINUX,
+                 source=Path("fail2ban"),
+                 interval=interval)
 
 register.bakery_plugin(
     name="fail2ban",
-    files_function=fail2ban,
+    files_function=get_fail2ban_files,
 )
-
-

--- a/lib/check_mk/base/plugins/agent_based/fail2ban_checks.py
+++ b/lib/check_mk/base/plugins/agent_based/fail2ban_checks.py
@@ -44,83 +44,74 @@
 from .agent_based_api.v1 import *
 
 
+def parse_fail2ban(string_table):
+    parsed = {}
+
+    for line in string_table:
+        if line[:4] ==  ['Status', 'for', 'the', 'jail:']:
+            jail = line[4]
+            parsed[jail] = {}
+
+        if (line[:4]) == ['|', '|-', 'Currently', 'failed:']:
+            parsed[jail]['currentfailed'] = int(line[4])
+        elif (line[:4]) == ['|', '|-', 'Total', 'failed:']:
+            parsed[jail]['totalfailed'] = int(line[4])
+        elif (line[:3]) == ['|-', 'Currently', 'banned:']:
+            parsed[jail]['currentbanned'] = int(line[3])
+        elif (line[:3]) == ['|-', 'Total', 'banned:']:
+            parsed[jail]['totalbanned'] = int(line[3])
+
+    return parsed
+
+
 def discovery_fail2ban(section):
-    firstline = section[0]
-    if firstline[:2] == ['Detected', 'jails:']:
-        for jail in firstline[2:]:
-            yield Service(item=jail)
+    for name in section:
+        yield Service(item=name)
 
 
 def check_fail2ban(item, params, section):
-    currentjail = ""
-    currentfailedcrit = params["failed"][1]
-    currentfailedwarn = params["failed"][0]
-    currentbannedcrit = params["banned"][1]
-    currentbannedwarn = params["banned"][0]
+    currentfailedcrit = None if params["failed"][1] == 0 else params["failed"][1]
+    currentfailedwarn = None if params["failed"][0] == 0 else params["failed"][0]
+    currentbannedcrit = None if params["banned"][1] == 0 else params["banned"][1]
+    currentbannedwarn = None if params["banned"][0] == 0 else params["banned"][0]
 
-    # set variable to check for jails that are not there anymore
-    currentfailed = None
-    currentbanned = None
-    totalfailed = None
-    totalbanned = None
-
-    for entry in section:
-        if (entry[:3]) == ['Status', 'for', 'the']:
-            currentjail = entry[4]
-        elif currentjail != item:
-            # skip lines when this item is requested at the moment
-            continue
-        elif (entry[:4]) == ['|', '|-', 'Currently', 'failed:', ]:
-            currentfailed = int(entry[4])
-        elif (entry[:4]) == ['|', '|-', 'Total', 'failed:', ]:
-            totalfailed = int(entry[4])
-        elif (entry[:3]) == ['|-', 'Currently', 'banned:', ]:
-            currentbanned = int(entry[3])
-        elif (entry[:3]) == ['|-', 'Total', 'banned:', ]:
-            totalbanned = int(entry[3])
-
-    # removed jails should not create a crash,
-    # so we dont yield anything and simply return without anything
-    if (currentfailed is None) or \
-            (totalfailed is None) or \
-            (currentbanned is None) or \
-            (totalbanned is None):
-        return
-    elif currentfailedcrit <= currentfailed or \
-            currentbannedcrit <= currentbanned:
-        s = State.CRIT
-        status = "Crit"
-    elif currentfailedwarn <= currentfailed or \
-            currentbannedwarn <= currentbanned:
-        s = State.WARN
-        status = "Warn"
+    if item in section:
+        currentfailed = section[item]['currentfailed']
+        currentbanned = section[item]['currentbanned']
+        totalfailed   = section[item]['totalfailed']
+        totalbanned   = section[item]['totalbanned']
     else:
-        s = State.OK
-        status = "OK"
+        yield Result(state=State.UNKNOWN, summary="Jail status not found in agent output.")
+        return
+
+    yield from check_levels(
+        currentfailed,
+        levels_upper=(currentfailedwarn, currentfailedcrit),
+        metric_name="current_failed",
+        render_func=lambda v: "%d" % v,
+        label=f"Total failed: {totalfailed}, Current failed",
+        boundaries=(0, None)
+        )
 
     yield Metric(
-            name="current_failed",
-            value=currentfailed,
-            levels=(currentfailedwarn, currentfailedcrit)
-            )
-    yield Metric(
-            name="total_failed",
-            value=totalfailed,
-            )
-    yield Metric(
-            name="current_banned",
-            value=currentbanned,
-            levels=(currentbannedwarn, currentbannedcrit)
-            )
-    yield Metric(
-            name="total_banned",
-            value=totalbanned,
-            )
+        name="total_failed",
+        value=totalfailed,
+        )
 
-    yield Result(
-            state=s,
-            summary=f"{status} - {item} active - {currentfailed} failed ({totalfailed} total), {currentbanned} banned ({totalbanned} total)"
-            )
+    yield from check_levels(
+        currentbanned,
+        levels_upper=(currentbannedwarn,  currentbannedcrit),
+        metric_name="current_banned",
+        render_func=lambda v: "%d" % v,
+        label=f"Total banned: {totalbanned}, Current banned",
+        boundaries=(0, None)
+        )
+
+    yield Metric(
+        name="total_banned",
+        value=totalbanned,
+        )
+
     return
 
 
@@ -129,6 +120,11 @@ register.check_plugin(
         service_name="Jail %s",
         discovery_function=discovery_fail2ban,
         check_function=check_fail2ban,
-        check_default_parameters={'banned': (10, 20), 'failed': (30, 40)},
+        check_default_parameters={'banned': (25, 50), 'failed': (50, 100)},
         check_ruleset_name="fail2ban",
         )
+
+register.agent_section(
+    name = "fail2ban",
+    parse_function = parse_fail2ban,
+)

--- a/web/plugins/wato/fail2ban_cee.py
+++ b/web/plugins/wato/fail2ban_cee.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: Checkmk Enterprise License
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+from cmk.gui.i18n import _
+from cmk.gui.plugins.wato import (
+    HostRulespec,
+    rulespec_registry,
+)
+from cmk.gui.cee.plugins.wato.agent_bakery.rulespecs.utils import RulespecGroupMonitoringAgentsAgentPlugins
+from cmk.gui.valuespec import (
+    Age,
+    Alternative,
+    Dictionary,
+    FixedValue,
+    Password,
+    TextAscii,
+    Tuple,
+)
+
+
+def _valuespec_agent_config_fail2ban():
+    return Alternative(
+        title = _("Fail2Ban (Linux)"),
+        help  = _("This will deploy the agent plugin <tt>fail2ban</tt> to check various jails."),
+        elements=[
+            Dictionary(
+                title=_("Deploy the Fail2Ban plugin"),
+                elements=[
+                    (
+                        "interval",
+                        Age(title=_("Run asynchronously"),
+                            label=_("Interval for collecting data"),
+                            default_value=300),
+                    ),
+                ],
+            ),
+            FixedValue(
+                None,
+                title=_("Do not deploy the Fail2Ban plugin"),
+                totext=_("(disabled)"),
+            ),
+        ],
+    )
+
+
+rulespec_registry.register(
+    HostRulespec(
+        group=RulespecGroupMonitoringAgentsAgentPlugins,
+        name="agent_config:fail2ban",
+        valuespec=_valuespec_agent_config_fail2ban,
+    ))

--- a/web/plugins/wato/fail2ban_parameters.py
+++ b/web/plugins/wato/fail2ban_parameters.py
@@ -41,20 +41,22 @@ def _parameter_valuespec_fail2ban():
              Tuple(
                  title=_("Number of banned IPs"),
                  help=_("This number of IPs have failed multiple times and "
-                        "are banned of a configure amount of times."),
+                        "have been banned for a configured number of times. "
+                        "(Set to 0 to disable)"),
                  elements=[
-                     Integer(title=_("Warning at")),
-                     Integer(title=_("Critical at")),
+                     Integer(title=_("Warning at"), default_value=25),
+                     Integer(title=_("Critical at"), default_value=50),
                  ],
              )),
          ("failed",
              Tuple(
                  title=_("Number of failed IPs"),
                  help=_("This number of IPs have failed logins. "
-                        "If this happens multiple times they will be banned."),
+                        "If this happens multiple times they will be banned. "
+                        "(Set to 0 to disable)"),
                  elements=[
-                     Integer(title=_("Warning at")),
-                     Integer(title=_("Critical at")),
+                     Integer(title=_("Warning at"), default_value=50),
+                     Integer(title=_("Critical at"), default_value=100),
                  ],
              )),
         ],


### PR DESCRIPTION
- Plugin modified to full support the new API and the parse function
- Restore of the levels from the old plugin
- Manage the threshold "0" to disable the check of the levels (as per old plugin)
- Remove from the agent  output the list of banned plugin (compatible with the old agent)
- Backery support for 2.0 and CEE
