### PR TITLE
Fix AttributeError in fail2ban_bakery.py

### DIFF
--- a/web/plugins/wato/fail2ban_bakery.py
+++ b/web/plugins/wato/fail2ban_bakery.py
@@ -46,7 +46,7 @@ def _valuespec_agent_config_fail2ban():
                 ),
             ),
         ],
-    ),
+    )
 
 
 


### PR DESCRIPTION
Exception:
`AttributeError ('tuple' object has no attribute 'title')`

Traceback:
```
  File "/omd/sites/zdv/lib/python3/cmk/gui/wsgi/applications/checkmk.py", line 188, in _process_request
    resp = page_handler()
  File "/omd/sites/zdv/lib/python3/cmk/gui/wsgi/applications/utils.py", line 113, in _call_auth
    func()
  File "/omd/sites/zdv/lib/python3/cmk/gui/pages.py", line 187, in wrapper
    return hc().handle_page()
  File "/omd/sites/zdv/lib/python3/cmk/gui/pages.py", line 51, in handle_page
    self.page()
  File "/omd/sites/zdv/lib/python3/cmk/gui/pages.py", line 146, in <lambda>
    "page": lambda self: self._wrapped_callable[0](),
  File "/omd/sites/zdv/lib/python3/cmk/gui/wato/page_handler.py", line 94, in page_handler
    _wato_page_handler(current_mode, mode_instance)
  File "/omd/sites/zdv/lib/python3/cmk/gui/wato/page_handler.py", line 150, in _wato_page_handler
    mode.handle_page()
  File "/omd/sites/zdv/lib/python3/cmk/gui/watolib/mode/_base.py", line 172, in handle_page
    return self.page()
  File "/omd/sites/zdv/lib/python3/cmk/gui/wato/pages/object_parameters.py", line 144, in page
    for rulespec in sorted(
  File "/omd/sites/zdv/lib/python3/cmk/gui/wato/pages/object_parameters.py", line 145, in <lambda>
    rulespec_registry.get_by_group(groupname), key=lambda x: x.title or ""
  File "/omd/sites/zdv/lib/python3/cmk/gui/watolib/rulespecs.py", line 400, in title
    plain_title = self._title() if self._title else self.valuespec.title()
```